### PR TITLE
Add Helm chart for authz-listeners

### DIFF
--- a/helm/authz-listeners/Chart.yaml
+++ b/helm/authz-listeners/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: authz-listeners
+description: Authorization service for Discord-like application using SpiceDB
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - authorization
+  - spicedb
+  - rabbitmq
+  - authzed
+maintainers:
+  - name: Beep Industries

--- a/helm/authz-listeners/templates/_helpers.tpl
+++ b/helm/authz-listeners/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "authz-listeners.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "authz-listeners.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "authz-listeners.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "authz-listeners.labels" -}}
+helm.sh/chart: {{ include "authz-listeners.chart" . }}
+{{ include "authz-listeners.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "authz-listeners.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "authz-listeners.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "authz-listeners.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "authz-listeners.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the secret to use
+*/}}
+{{- define "authz-listeners.secretName" -}}
+{{- if .Values.secrets.existingSecret }}
+{{- .Values.secrets.existingSecret }}
+{{- else }}
+{{- include "authz-listeners.fullname" . }}
+{{- end }}
+{{- end }}

--- a/helm/authz-listeners/templates/configmap.yaml
+++ b/helm/authz-listeners/templates/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "authz-listeners.fullname" . }}
+  labels:
+    {{- include "authz-listeners.labels" . | nindent 4 }}
+data:
+  AUTHZED_ENDPOINT: {{ .Values.config.authzed.endpoint | quote }}
+  AUTHZED_INSECURE: {{ .Values.config.authzed.insecure | quote }}
+  RABBIT_CONSUMER_TAG_SUFFIX: {{ .Values.config.rabbitmq.consumerTagSuffix | quote }}
+  RUST_LOG: {{ .Values.config.logLevel | quote }}
+  queues.json: |
+    {{- .Values.queues | toPrettyJson | nindent 4 }}

--- a/helm/authz-listeners/templates/deployment.yaml
+++ b/helm/authz-listeners/templates/deployment.yaml
@@ -27,6 +27,51 @@ spec:
       serviceAccountName: {{ include "authz-listeners.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.migration.enabled }}
+      initContainers:
+        - name: schema-loader
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.migration.image.repository }}:{{ .Values.migration.image.tag }}"
+          imagePullPolicy: {{ .Values.migration.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              echo "Waiting for SpiceDB to be ready..."
+              for i in $(seq 1 30); do
+                if grpcurl -plaintext {{ .Values.config.authzed.endpoint }} list > /dev/null 2>&1; then
+                  echo "SpiceDB is ready"
+                  break
+                fi
+                echo "Attempt $i: Waiting for SpiceDB..."
+                sleep 2
+              done
+
+              echo "Loading schema..."
+              zed schema write \
+                --endpoint={{ .Values.config.authzed.endpoint }} \
+                {{- if eq .Values.config.authzed.insecure "true" }}
+                --insecure \
+                {{- end }}
+                --token="$AUTHZED_TOKEN" \
+                /beep/beep.zed
+
+              echo "Schema loaded successfully"
+          env:
+            - name: AUTHZED_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "authz-listeners.secretName" . }}
+                  key: AUTHZED_TOKEN
+          volumeMounts:
+            - name: schema
+              mountPath: /beep
+              readOnly: true
+          resources:
+            {{- toYaml .Values.migration.resources | nindent 12 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -79,6 +124,11 @@ spec:
             items:
               - key: queues.json
                 path: queues.json
+        {{- if .Values.migration.enabled }}
+        - name: schema
+          configMap:
+            name: {{ include "authz-listeners.fullname" . }}-schema
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/authz-listeners/templates/deployment.yaml
+++ b/helm/authz-listeners/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "authz-listeners.fullname" . }}
+  labels:
+    {{- include "authz-listeners.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "authz-listeners.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "authz-listeners.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "authz-listeners.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: AUTHZED_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "authz-listeners.fullname" . }}
+                  key: AUTHZED_ENDPOINT
+            - name: AUTHZED_INSECURE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "authz-listeners.fullname" . }}
+                  key: AUTHZED_INSECURE
+            - name: RABBIT_CONSUMER_TAG_SUFFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "authz-listeners.fullname" . }}
+                  key: RABBIT_CONSUMER_TAG_SUFFIX
+            - name: RUST_LOG
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "authz-listeners.fullname" . }}
+                  key: RUST_LOG
+            - name: QUEUE_CONFIG_PATH
+              value: "/app/config/queues.json"
+            - name: AUTHZED_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "authz-listeners.secretName" . }}
+                  key: AUTHZED_TOKEN
+            - name: RABBIT_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "authz-listeners.secretName" . }}
+                  key: RABBIT_URI
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+              readOnly: true
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "authz-listeners.fullname" . }}
+            items:
+              - key: queues.json
+                path: queues.json
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/authz-listeners/templates/schema-configmap.yaml
+++ b/helm/authz-listeners/templates/schema-configmap.yaml
@@ -1,0 +1,343 @@
+{{- if .Values.migration.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "authz-listeners.fullname" . }}-schema
+  labels:
+    {{- include "authz-listeners.labels" . | nindent 4 }}
+    app.kubernetes.io/component: schema
+data:
+  beep.zed: |
+    /**
+     * user represents a person using the Discord-like application
+     */
+    definition user {}
+    
+    
+    /**
+     * server represents a Discord-like server/guild that users can join
+     */
+    definition server {
+        /**
+         * owner indicates the user who owns and has full control over the server
+         */
+        relation owner: user
+    
+        /**
+         * message_sender indicates roles that can send messages in this server
+         */
+        relation message_sender: role#member
+    
+        /**
+         * send_message indicates permission to send messages in this server
+         */
+        permission send_message = owner + message_sender
+    
+        /**
+         * channel_viewer indicates roles that can view channels in this server
+         */
+        relation channel_viewer: role#member
+    
+        /**
+         * view_channel indicates permission to view channels in this server
+         */
+        permission view_channel = owner + channel_viewer
+    
+        /**
+         * message_manager indicates roles that can manage (delete other) messages in this server
+         */
+        relation message_manager: role#member
+    
+        /**
+         * manage_message indicates permission to manage messages in this server
+         */
+        permission manage_message = owner + message_manager
+    
+        /**
+         * file_attacher indicates roles that can attach files to messages in this server
+         */
+        relation file_attacher: role#member
+    
+        /**
+         * attach_files indicates permission to attach files in this server
+         */
+        permission attach_files = owner + file_attacher
+    
+        /**
+         * webhook_manager indicates roles that can manage webhooks in this server
+         */
+        relation webhook_manager: role#member
+    
+        /**
+         * manage_webhooks indicates permission to manage webhooks in this server
+         */
+        permission manage_webhooks = owner + webhook_manager
+    
+        /**
+         * role_manager indicates roles that can manage (create/edit/delete) roles in this server
+         */
+        relation role_manager: role#member
+    
+        /**
+         * manage_role indicates permission to manage (create/edit/delete) roles in this server
+         */
+        permission manage_role = owner + role_manager
+    
+        /**
+         * role_viewer indicates roles that can view (list/read) role information in this server
+         */
+        relation role_viewer: role#member
+    
+        /**
+         * view_role indicates permission to view (list/read) role information in this server
+         */
+        permission view_role = owner + role_viewer
+    
+        /**
+         * server_manager indicates roles that can manage (edit/delete) the server
+         */
+        relation server_manager: role#member
+    
+        /**
+         * manage indicates permission to manage (edit/delete) the server
+         */
+        permission manage = owner + server_manager
+    
+        /**
+         * server_viewer indicates roles that can view server information
+         */
+        relation server_viewer: role#member
+    
+        /**
+         * view indicates permission to view server information
+         */
+        permission view = owner + server_viewer
+    
+        /**
+         * nickname_manager indicates roles that can manage (edit any user) nicknames in this server
+         */
+        relation nickname_manager: role#member
+    
+        /**
+         * manage_nicknames indicates permission to manage (edit any user) nicknames in this server
+         */
+        permission manage_nicknames = owner + nickname_manager
+    
+        /**
+         * nickname_changer indicates roles that can change their own nickname in this server
+         */
+        relation nickname_changer: role#member
+    
+        /**
+         * change_nickname indicates permission to change your own nickname in this server
+         */
+        permission change_nickname = owner + nickname_changer
+    
+        /**
+         * channel_manager indicates roles that can manage (create/edit/delete) channels in this server
+         */
+        relation channel_manager: role#member
+    
+        /**
+         * manage_channels indicates permission to manage (create/edit/delete) channels in this server
+         */
+        permission manage_channels = owner + channel_manager
+    
+        /**
+         * invitation_creator indicates roles that can create invitations in this server
+         */
+        relation invitation_creator: role#member
+    
+        /**
+         * create_invitation indicates permission to create server invitations
+         */
+    
+        /**
+         * administrator indicates roles that have full administrative access to everything in this server
+         */
+        relation administrator: role#member
+    
+        /**
+         * admin indicates full administrative permission to do any action on any subject in this server
+         */
+        permission admin = owner + administrator
+    }
+    
+    /**
+     * role represents a permission container that can be assigned to server members
+     * Roles can have permission overrides (grant/deny) similar to channels
+     */
+    definition role {
+        /**
+         * server indicates which server this role belongs to
+         */
+        relation server: server
+    
+        /**
+         * member indicates users who have been assigned this role
+         */
+        relation member: user
+    
+        /**
+         * manage_role_grant indicates explicit permission grants for managing roles
+         */
+        relation manage_role_grant: user | role#member
+    
+        /**
+         * manage_role_deny indicates explicit permission denies for managing roles
+         */
+        relation manage_role_deny: user | role#member
+    
+        /**
+         * manage indicates permission to manage (create/edit/delete) roles
+         * Denies take precedence over grants
+         */
+        permission manage = (server->manage_role + manage_role_grant) - manage_role_deny
+    
+        /**
+         * view_role_grant indicates explicit permission grants for viewing roles
+         */
+        relation view_role_grant: user | role#member
+    
+        /**
+         * view_role_deny indicates explicit permission denies for viewing roles
+         */
+        relation view_role_deny: user | role#member
+    
+        /**
+         * view indicates permission to view (list/read) role information
+         * Denies take precedence over grants
+         */
+        permission view = (server->view_role + view_role_grant) - view_role_deny
+    }
+    
+    /**
+     * channel represents a communication channel within a server
+     */
+    definition channel {
+        /**
+         * server indicates which server this channel belongs to
+         */
+        relation server: server
+    
+        /**
+         * send_message_grant indicates explicit permission grants for sending messages
+         * Can come from users, roles, or permission_override objects
+         */
+        relation send_message_grant: user | role#member | permission_override#granted_to
+    
+        /**
+         * send_message_deny indicates explicit permission denies for sending messages
+         * Can come from users, roles, or permission_override objects
+         */
+        relation send_message_deny: user | role#member | permission_override#denied_to
+    
+        /**
+         * send_message indicates permission to send messages in the channel
+         * Denies take precedence over grants
+         */
+        permission send_message = (server->send_message + send_message_grant) - send_message_deny
+    
+        /**
+         * view_channel_grant indicates explicit permission grants for viewing the channel
+         * Can come from users, roles, or permission_override objects
+         */
+        relation view_channel_grant: user | role#member | permission_override#granted_to
+    
+        /**
+         * view_channel_deny indicates explicit permission denies for viewing the channel
+         * Can come from users, roles, or permission_override objects
+         */
+        relation view_channel_deny: user | role#member | permission_override#denied_to
+    
+        /**
+         * view indicates permission to view the channel
+         * Denies take precedence over grants
+         */
+        permission view = (server->view_channel + view_channel_grant) - view_channel_deny
+    
+        /**
+         * manage_message_grant indicates explicit permission grants for managing messages
+         * Can come from users, roles, or permission_override objects
+         */
+        relation manage_message_grant: user | role#member | permission_override#granted_to
+    
+        /**
+         * manage_message_deny indicates explicit permission denies for managing messages
+         * Can come from users, roles, or permission_override objects
+         */
+        relation manage_message_deny: user | role#member | permission_override#denied_to
+    
+        /**
+         * manage_message indicates permission to manage (delete other) messages in the channel
+         * Denies take precedence over grants
+         */
+        permission manage_message = (server->manage_message + manage_message_grant) - manage_message_deny
+    
+        /**
+         * attach_files_grant indicates explicit permission grants for attaching files
+         * Can come from users, roles, or permission_override objects
+         */
+        relation attach_files_grant: user | role#member | permission_override#granted_to
+    
+        /**
+         * attach_files_deny indicates explicit permission denies for attaching files
+         * Can come from users, roles, or permission_override objects
+         */
+        relation attach_files_deny: user | role#member | permission_override#denied_to
+    
+        /**
+         * attach_files indicates permission to attach files to messages in the channel
+         * Denies take precedence over grants
+         */
+        permission attach_files = (server->attach_files + attach_files_grant) - attach_files_deny
+    
+        /**
+         * manage_webhooks_grant indicates explicit permission grants for managing webhooks
+         * Can come from users, roles, or permission_override objects
+         */
+        relation manage_webhooks_grant: user | role#member | permission_override#granted_to
+    
+        /**
+         * manage_webhooks_deny indicates explicit permission denies for managing webhooks
+         * Can come from users, roles, or permission_override objects
+         */
+        relation manage_webhooks_deny: user | role#member | permission_override#denied_to
+    
+        /**
+         * manage_webhooks indicates permission to manage webhooks in the channel
+         * Denies take precedence over grants
+         */
+        permission manage_webhooks = (server->manage_webhooks + manage_webhooks_grant) - manage_webhooks_deny
+    }
+    
+    /**
+     * permission_override represents a stored permission override for tracking and deletion
+     * The permission_override object itself is linked to channel grant/deny relations
+     * This allows us to delete all related permissions by deleting the override object
+     */
+    definition permission_override {
+        /**
+         * channel indicates which channel this override applies to
+         */
+        relation channel: channel
+    
+        /**
+         * granted_to indicates the user or role that receives the grant permission
+         * This is set when the override action is ALLOW
+         */
+        relation granted_to: user | role#member
+    
+        /**
+         * denied_to indicates the user or role that receives the deny permission
+         * This is set when the override action is DENY
+         */
+        relation denied_to: user | role#member
+    
+        /**
+         * view indicates permission to view this override's details
+         * Note: Simplified because nested arrows (channel->server->admin) are not yet supported
+         */
+        permission view = granted_to + denied_to
+    }
+{{- end }}

--- a/helm/authz-listeners/templates/secret.yaml
+++ b/helm/authz-listeners/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "authz-listeners.fullname" . }}
+  labels:
+    {{- include "authz-listeners.labels" . | nindent 4 }}
+type: Opaque
+data:
+  AUTHZED_TOKEN: {{ .Values.secrets.authzedToken | b64enc | quote }}
+  RABBIT_URI: {{ .Values.secrets.rabbitUri | b64enc | quote }}
+{{- end }}

--- a/helm/authz-listeners/templates/serviceaccount.yaml
+++ b/helm/authz-listeners/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "authz-listeners.serviceAccountName" . }}
+  labels:
+    {{- include "authz-listeners.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/authz-listeners/values.yaml
+++ b/helm/authz-listeners/values.yaml
@@ -91,3 +91,23 @@ securityContext:
   capabilities:
     drop:
       - ALL
+
+# SpiceDB schema migration configuration
+migration:
+  # Enable/disable SpiceDB schema initialization
+  enabled: true
+  # Image for schema loader (zed CLI)
+  image:
+    repository: authzed/zed
+    tag: "latest-debug"
+    pullPolicy: IfNotPresent
+  # Resource limits for init container
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+  # Number of retries before the init container fails
+  backoffLimit: 3

--- a/helm/authz-listeners/values.yaml
+++ b/helm/authz-listeners/values.yaml
@@ -1,0 +1,93 @@
+# Default values for authz-listeners
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/beep-industries/authz
+  tag: "0.0.1"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# Application configuration
+config:
+  authzed:
+    # SpiceDB/AuthZed gRPC endpoint
+    endpoint: "spicedb:50051"
+    # Use insecure connection (no TLS)
+    insecure: "true"
+  rabbitmq:
+    # Suffix appended to consumer tags for identification
+    consumerTagSuffix: "default"
+  # Rust log level (trace, debug, info, warn, error)
+  logLevel: "info"
+
+# Secrets configuration
+secrets:
+  # SpiceDB pre-shared key for authentication
+  authzedToken: ""
+  # RabbitMQ connection URI (amqp://user:pass@host:port)
+  rabbitUri: ""
+  # Use existing secret instead of creating one
+  # If set, secrets.authzedToken and secrets.rabbitUri are ignored
+  existingSecret: ""
+
+# Queue configuration (maps to queues.json)
+queues:
+  server:
+    create_server: "create.server.queue"
+    delete_server: "delete.server.queue"
+  channel:
+    create_channel: "create.channel.queue"
+    delete_channel: "delete.channel.queue"
+  role:
+    upsert_role: "role.upsert.queue"
+    delete_role: "role.delete.queue"
+    member_assigned_to_role: "member.assign.role.queue"
+    member_removed_from_role: "member.unassign.role.queue"
+  permission_override:
+    upsert_permission_override: "permission_override.upsert_permission_override.queue"
+    delete_permission_override: "permission_override.delete_permission_override.queue"
+
+# Resource limits and requests
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+# Pod scheduling constraints
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Pod annotations
+podAnnotations: {}
+
+# Pod security context
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+  fsGroup: 1001
+
+# Container security context
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Helm chart to deploy the authorization listeners service with configurable deployment, init logic, and optional schema migration.
  * Includes templated ConfigMap, Secret, ServiceAccount, and resource scheduling/security settings.

* **Chores**
  * Provided default values for image, secrets, queue configuration, logging, resources, and pod/container security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->