### PR TITLE
fix: add create invitation to beep authzed schema and helm

### DIFF
--- a/authzed/beep.zed
+++ b/authzed/beep.zed
@@ -141,6 +141,7 @@ definition server {
     /**
      * create_invitation indicates permission to create server invitations
      */
+    permission create_invitation = owner + invitation_creator
 
     /**
      * administrator indicates roles that have full administrative access to everything in this server

--- a/helm/authz-listeners/templates/schema-configmap.yaml
+++ b/helm/authz-listeners/templates/schema-configmap.yaml
@@ -151,7 +151,8 @@ data:
         /**
          * create_invitation indicates permission to create server invitations
          */
-    
+        permission create_invitation = owner + invitation_creator
+
         /**
          * administrator indicates roles that have full administrative access to everything in this server
          */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `create_invitation` permission that grants invitation creation capabilities to users with owner or invitation creator roles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->